### PR TITLE
Updated readme to use https instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On a fresh terminal:
 
 Followed by:
 
-`git clone git@github.com:igmhub/LaCE.git`
+`git clone https://github.com/igmhub/LaCE.git`
 
 `cd LaCE`
 


### PR DESCRIPTION
We shouldn't need the cloning account to be associated with an `ssh` key really. There are benefits to cloning with ssh for people interested in doing development, but not sure this should be the recommended procedure. What do you think?