### PR TITLE
avoid camb imports

### DIFF
--- a/lace/archive/gadget_archive.py
+++ b/lace/archive/gadget_archive.py
@@ -5,7 +5,6 @@ import os
 import json
 
 from lace.setup_simulations import read_genic, read_gadget
-from lace.cosmo import camb_cosmo, fit_linP
 from lace.archive.base_archive import BaseArchive
 from lace.utils.exceptions import ExceptionList
 
@@ -285,6 +284,9 @@ class GadgetArchive(BaseArchive):
                     break
 
         if self.update_kp == True:
+            # this is the only place you actually need CAMB
+            from lace.cosmo import camb_cosmo, fit_linP
+
             _, sim_name_param, tag_param = self._sim2file_name(sim_label)
             pair_dir = self.fulldir_param + "/" + sim_name_param
 

--- a/lace/archive/nyx_archive.py
+++ b/lace/archive/nyx_archive.py
@@ -2,7 +2,6 @@ import numpy as np
 import os
 import h5py
 
-from lace.cosmo import camb_cosmo, fit_linP
 from lace.cosmo.thermal_broadening import thermal_broadening_kms
 from lace.archive.base_archive import BaseArchive
 from lace.utils.misc import split_string
@@ -210,6 +209,9 @@ class NyxArchive(BaseArchive):
                     break
 
         if self.update_kp == True:
+            # this is the only place where you need CAMB
+            from lace.cosmo import camb_cosmo, fit_linP
+
             sim_params = get_attrs(nyx_data[sim_label])
             if isim == "fiducial":
                 sim_params["A_s"] = 2.10e-9

--- a/lace/emulator/nn_emulator.py
+++ b/lace/emulator/nn_emulator.py
@@ -12,7 +12,6 @@ from torch import nn, optim
 from torch.optim import lr_scheduler
 
 # LaCE modules
-from lace.cosmo import camb_cosmo, fit_linP
 from lace.archive import gadget_archive, nyx_archive
 from lace.emulator import nn_architecture, base_emulator
 from lace.utils import poly_p1d


### PR DESCRIPTION
Avoid unnecessary imports of fit_linP and camb_cosmo, so that one can really run without CAMB