### PR TITLE
Lace nyx tests

### DIFF
--- a/lace/emulator/nn_architecture.py
+++ b/lace/emulator/nn_architecture.py
@@ -5,13 +5,13 @@ from torch import nn
 
 
 class MDNemulator_polyfit(torch.nn.Module):
-    def __init__(self, nhidden, ndeg, ninput=6):
+    def __init__(self, nhidden, ndeg, max_neurons=100, ninput=6):
         super().__init__()
         self.inputlay = torch.nn.Sequential(
             nn.Linear(ninput, 10), nn.LeakyReLU(0.5)
         )
 
-        params = np.linspace(10, 100, nhidden)
+        params = np.linspace(10, max_neurons, nhidden)
         modules = []
         for k in range(nhidden - 1):
             modules.append(nn.Linear(int(params[k]), int(params[k + 1])))
@@ -19,10 +19,10 @@ class MDNemulator_polyfit(torch.nn.Module):
         self.hiddenlay = nn.Sequential(*modules)
 
         self.means = torch.nn.Sequential(
-            nn.Linear(100, 50), nn.LeakyReLU(0.5), nn.Linear(50, ndeg + 1)
+            nn.Linear(max_neurons, 50), nn.LeakyReLU(0.5), nn.Linear(50, ndeg + 1)
         )
         self.stds = torch.nn.Sequential(
-            nn.Linear(100, 50), nn.LeakyReLU(0.5), nn.Linear(50, ndeg + 1)
+            nn.Linear(max_neurons, 50), nn.LeakyReLU(0.5), nn.Linear(50, ndeg + 1)
         )
 
     def forward(self, inp):

--- a/lace/emulator/nn_emulator.py
+++ b/lace/emulator/nn_emulator.py
@@ -191,7 +191,7 @@ class NNEmulator(base_emulator.BaseEmulator):
         elif emulator_label == "Nyx_v0":
             self.print(
                 r"Neural network emulating the optimal P1D of Nyx simulations "
-                + "fitting coefficients to a 5th degree polynomial. It "
+                + "fitting coefficients to a 6th degree polynomial. It "
                 + "goes to scales of 4Mpc^{-1} and z<=4.5. The parameters "
                 + "passed to the emulator will be overwritten to match "
                 + "these ones"
@@ -212,7 +212,7 @@ class NNEmulator(base_emulator.BaseEmulator):
                 self.nhidden,
                 self.max_neurons,
                 self.lr0
-            ) = (4, 6, 800, 700, 5, 150, 5e-4)
+            ) = (4, 6, 800, 700, 5, 150, 5e-5)
 
         elif emulator_label == "Cabayol23_extended":
             self.print(

--- a/lace/emulator/nn_emulator.py
+++ b/lace/emulator/nn_emulator.py
@@ -535,7 +535,7 @@ class NNEmulator(base_emulator.BaseEmulator):
             ninput=len(self.emu_params)
         )
 
-        optimizer = optim.AdamW(
+        optimizer = optim.Adam(
             self.nn.parameters(), lr=self.lr0,weight_decay=1e-4
         )  #
         scheduler = lr_scheduler.StepLR(optimizer, self.step_size, gamma=0.1)


### PR DESCRIPTION
This branch updates the nyx version to one providing much better results on a L1O dropping the entire simulation from the traning sample (not snapshot by snapshot).
I have also realized that we are using Adam and not AdamW. At some point we were using AdamW, but I guess we lost it in some commit... There is no big impact when changing the optimizer. I leave Adam until I test the impact this change has on LaCE_mpg. 
