### PR TITLE
Scale rescalings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .github/workflows/.python-tests.yml.swo
 .github/workflows/.python-tests.yml.swp
 docs/build/
+docs/site/

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ NYX_PATH="/global/cfs/cdirs/desi/science/lya/y1-p1d/likelihood_files/nyx_files/"
 - Before running LaCE, please precompute all cosmological information needed using CAMB and save IGM histories. This is done by running the following scripts. You do not need to do it if you are in NERSC.
 
 ```
-python scripts/save_nyx_emu_cosmo.py
-python scripts/save_nyx_IGM.py
+python scripts/developers/save_nyx_emu_cosmo.py
+python scripts/developers/save_nyx_IGM.py
 ```
 
 ## Emulator parameters:

--- a/docs/docs/developers/CreateNewEmulator.md
+++ b/docs/docs/developers/CreateNewEmulator.md
@@ -1,0 +1,104 @@
+# CREATING NEW EMULATORS
+
+The training of the emulators is done with the code `train.py`. This code is used to train custom emulators already defined with an emulator label. However, you might need to define a new emulator label with new hyperparameters. This tutorial will guide you through the process of creating a new emulator label.
+
+The file `lace/emulator/constants.py` contains the definitions of the emulator labels, training sets, and the emulator parameters associated with each emulator label.
+
+To create a new emulator label, you first need to add your new emulator label to the `EmulatorLabel` class in the `constants.py` file, for example:
+
+```python
+class EmulatorLabel(StrEnum):
+    ...
+    NEW_EMULATOR = "New_Emulator"
+```
+
+"New emulator" is the name of the new emulator label that identifies it in the emulator calls, e.g. `NNEmulator(emulator_label="New_Emulator")`.
+
+Then this label needs to be added to `GADGET_LABELS` or `NYX_LABELS` in the `constants.py` file, depending on the training set you used to train your emulator. For example, if this is a new Gadget emulator, you need to add it to `GADGET_LABELS`:
+
+```python
+GADGET_LABELS = {
+    ...
+    EmulatorLabel.NEW_EMULATOR,
+}
+```
+
+The dictionary `EMULATOR_PARAMS` also needs to be updated with the new emulator parameters. Here, one needs to add all the arguments needed to initialize the emulator class. For example:
+
+```python
+    "Nyx_alphap_cov": {
+        "emu_params": [
+            "Delta2_p",
+            "n_p",
+            "alpha_p",
+            "mF",
+            "sigT_Mpc",
+            "gamma",
+            "kF_Mpc",
+        ],
+        "emu_type": "polyfit",
+        "kmax_Mpc": 4,
+        "ndeg": 6,
+        "nepochs": 600,
+        "step_size": 500,
+        "nhidden": 6,
+        "max_neurons": 400,
+        "lr0": 2.5e-4,
+        "weight_decay": 8e-3,
+        "batch_size": 100,
+        "amsgrad": True,
+        "z_max": 5,
+        "include_central": False,
+    }
+```
+
+Finally, you need to add a description of the new emulator in the `EMULATOR_DESCRIPTIONS` dictionary:
+
+```python
+EMULATOR_DESCRIPTIONS = {
+    ...
+    EmulatorLabel.NEW_EMULATOR: "Description of the new emulator",
+}
+```
+With this, you have added a new emulator label to the code! You should be able to train your new emulator with the command:
+
+```bash
+python scripts/train.py --config=path/to/config.yaml
+```
+or call the emulator directly with:
+
+```python
+emulator = NNEmulator(emulator_label="New_Emulator",
+                      archive=archive)
+```
+
+
+## Loading the new emulator
+Once you have defined a new emulator label, you might want to save the trained emulator models and load them without the need of retraining. This can be done either specifying the `model_path` argument when initializing the emulator. 
+
+```python
+emulator = NNEmulator(emulator_label="New_Emulator",
+                      model_path="path/to/model.pt",
+                      train=False,
+                      archive=archive)
+```
+And also using the `emulator_manager` function:
+
+```python
+emulator = emulator_manager(emulator_label="New_Emulator"
+                            archive=archive)
+```
+
+In the first case, since you are specifying the `model path`, there is no naming convention for the model file. However, in the second case, the saved models must be stored in the following way:
+- The folder must be  `data/NNmodels/` from the root of the repository.
+- For a specific emulator label, you need to create a new folder, e.g. `New_Emulator`.
+- For the emulator using all training simulations, the model file is named `New_Emulator.pt`.
+- For the emulator using the training set excluding a given simulation, the model file is named `New_Emulator_drop_sim_{simulation suite}_{simulation index}.pt`. For example, if you exclude the 10th simulation from the mpg training set, the model file is named `New_Emulator_drop_sim_mpg_10.pt`.   
+
+The emulator manager will automatically find the correct model file for the given emulator label. To set this up, you need to add the new emulator label to the `folder` dictionary in the `emulator_manager.py` file.
+```python
+folder = {
+    ...
+    EmulatorLabel.NEW_EMULATOR: "NNmodels/New_Emulator/",
+}
+```

--- a/docs/docs/developers/advancedTesting.md
+++ b/docs/docs/developers/advancedTesting.md
@@ -1,0 +1,26 @@
+# MAINTAINING THE AUTOMATED TESTING
+
+LaCE uses automated testing to ensure code quality and prevent regressions. This guide explains how to maintain and extend the test suite. This section is intended for developers who are maintaining the automated testing.
+
+## Running Tests
+Automated tests are run using pytest. The tests pipeline is at `.github/workflows/python-tests.yml`. To add another test, you have to:
+
+1. In the section `Run tests`, in `.github/workflows/python-tests.yml`, add the command to run your test.
+```yaml
+    - name: Run tests
+      run: |
+        ...
+        pytest tests/test_your_test.py
+        pytest tests/test_your_other_test.py
+```
+2. Add the script with your test in the `tests` folder.
+3. The testing function must start with `test_` (e.g., `test_my_function`). Tests can take fixtures as arguments.
+
+In the `.github/workflows/python-tests.yml` file, you can specify when the test should be run. For example, currently tests are only run after a PR to the `main` branch.
+```yaml
+    on:
+    push:
+        branches: 'main'
+```
+
+When a PR is merged into the `main` branch, the tests are run automatically at [Github Actions](https://github.com/igmhub/LaCE/actions).

--- a/docs/docs/developers/documentation.md
+++ b/docs/docs/developers/documentation.md
@@ -1,0 +1,25 @@
+# MAINTAINING THE DOCUMENTATION
+
+LaCE uses `mkdocs` to build the documentation. The documentation is hosted at [LaCE documentation](https://igmhub.github.io/LaCE/). The documentation can be built locally using the following command:
+
+```bash
+mkdocs build
+``` 
+and then served using
+
+```bash
+mkdocs serve
+```
+
+The documentation is pushed to the `gh-pages` branch at each release (merge into `main`).
+The `gh-pages` branch is automatically updated when a PR is merged into `main`.
+
+In order to write documentation, you can use the following structure:
+
+- `docs/docs/developers`: Documentation for developers
+- `docs/docs/`: Documentation for users
+
+You can add new pages by adding a new `.md` file to the `docs/docs/` folder. Remember to add the new page to the `mkdocs.yml` file so that it is included in the documentation. The new page will automatically be added to the navigation menu. 
+
+To have a cleaner structure, add the new page to the corresponding `index.md` file.
+

--- a/docs/docs/developers/index.md
+++ b/docs/docs/developers/index.md
@@ -1,0 +1,20 @@
+# FOR DEVELOPERS    
+
+Welcome to the LaCE developer documentation! This section contains information for developers who want to contribute to LaCE or understand its internals better.
+
+## Contents
+
+- [Creating New Emulators](CreateNewEmulator.md): Learn how to create and add new emulator types to LaCE
+- [Training Options](trainingOptions.md): Implemented solutions to improve the emulators performance
+- [Code Testing](advancedTesting.md): Information to mantain and extend the automated testing
+- [Documentation](documentation.md): How to write and maintain documentation
+
+## Getting Started
+
+If you're new to developing for LaCE, we recommend:
+
+1. Reading the installation instructions
+2. Setting up your development environment
+3. ...
+
+For any questions, please open an issue on GitHub or reach out to the maintainers.

--- a/docs/docs/developers/trainingOptions.md
+++ b/docs/docs/developers/trainingOptions.md
@@ -1,0 +1,80 @@
+# TRAINING OPTIONS
+
+There are several features that can be used to customize the training of the emulators. This tutorial will guide you through the process of training emulators with different options.
+
+- [Weighting with a covariance matrix](#weighting-with-a-covariance-matrix)
+- [Weighting simulations depending of the scalings (mean flux, temperature )](#weighting-simulations-depending-of-the-scalings-mean-flux-temperature)
+
+## Weighting with a covariance matrix
+The emulator supports weighting the training simulations with a covariance matrix. This covariance matrix is used to weight the training simulations during the training of the neural network.
+
+To train an emulator with a covariance matrix, you need to provide a covariance matrix for the training simulations. Currently, the emulator only supports a diagonal covariance matrix. It is important that the covariance matrix is given in the __k__ binning of the training simulations.
+
+The function '_load_DESIY1_err' in the `nn_emulator.py` file loads a covariance matrix. The covariance must be a json file with the relative error as a function of __z__ for each __k__ bin.
+
+From the relative error file in 'data/DESI_cov/rel_err_DESI_Y1.npy', we can generate the json file with the following steps:
+
+First we load the data from the relative error file:
+
+```python
+cov =  np.load(PROJ_ROOT / "data/DESI_cov/rel_error_DESIY1.npy", allow_pickle=True)
+# Load the data dictionary
+data = cov.item()
+```
+
+Then we extract the arrays. This has a hidden important step. In the original relative error file, the values for the relative error are set to 100 correspond to the scales not measured by DESI. The value of 100 is set at random, and can be optimized for the training. Initial investigations indicated that setting the value to 5 was working well. However, this parameter could be furtehr refined. Currently is set to 5, but other values of this dummy value could be used.
+
+```python
+# Extract the arrays
+z_values = data['z']
+rel_error_Mpc = data['rel_error_Mpc']
+rel_error_Mpc[rel_error_Mpc == 100] = 5
+
+k_cov = data['k_Mpc']
+```
+
+Then we extract the __k__ values for the training simulations to ensure that the covariance matrix is given in the __k__ binning of the training simulations.
+
+```python
+testing_data_central = archive.get_testing_data('nyx_central')
+testing_data = archive.get_testing_data('nyx_0')
+k_Mpc_LH = testing_data[0]['k_Mpc'][testing_data[0]['k_Mpc']<4]
+```
+And then we create the dictionary with the relative error as a function of __z__ for each __k__ bin:
+
+```python
+# Load the data dictionary
+data = cov.item()
+z_values = data['z']
+
+dict_={}
+for z, rel_error_row in zip(z_values, rel_error_Mpc):
+    f = interp1d(k_cov, rel_error_row, fill_value="extrapolate")
+    rel_error_Mpc_interp = f(k_Mpc_LH)
+    rel_error_Mpc_interp[0:3] = rel_error_Mpc_interp[3]
+    dict_[f"{z}"]=rel_error_Mpc_interp.tolist()
+        
+# Create a new dictionary with z as keys and corresponding rel_error_Mpc rows as values
+#z_to_rel_error_serializable = {float(z): rel_error_row.tolist() for z, rel_error_row in z_to_rel_error.items()}
+```
+
+And finally we save the dictionary to a json file:
+
+```python
+# Save the z_to_rel_error dictionary to a JSON file
+with open(PROJ_ROOT / "data/DESI_cov/rerr_DESI_Y1.json", "w") as json_file:
+    json.dump(dict_, json_file, indent=4)
+```
+
+## Weighting simulations depending of the scalings (mean flux, temperature )
+
+The `nn_emulator.py` file contains a function `_get_rescalings_weights` that allows to weight the simulations depending on the scalings. This can be used to give more importance to the snapshots with certain scalings. It is possible to weight differently based on the scaling value and the redshift. Initial investigations did not show an improvement in the emulator performance when weighting the simulations. However, might be worth to further investigate this option.
+
+The function `_get_rescalings_weights` can be customized by changing the line:
+
+```python
+weights_rescalings[np.where([(d['val_scaling'] not in [0,1] and d['z'] in [2.8, 3,3.2,3.4]) for d in self.training_data])] = 1
+```
+The weight value of 1 does not have any effect on the training. To downweight certain snapshots, a value lower than 1 can be used. In this particular case, modifying it to a lower value, for example 0.5, would downweight the snapshots with a scaling value not equal to 0 or 1 (temparature scalings) and a redshift in the range [2.8, 3,3.2,3.4].
+
+Initial investigations showed that very low values of the weights, for example 0.01 already led to a similar performance to the one of an emulator trained with equal weights.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,4 @@
-# LaCE documentation!
+# LaCE DOCUMENTATION
 
 Welcome to the documentation for LaCE!
 LaCE contains a set of emulators for the one-dimensional flux power spectrum of the Lyman-alpha forest. It has been used in the papers:
@@ -9,14 +9,6 @@ LaCE contains a set of emulators for the one-dimensional flux power spectrum of 
 
 Please cite at least https://arxiv.org/abs/2305.19064 if you use this emulator in your research.
 
-
-## Table of Contents
-
-- [Installation](installation.md)
-- [Archive](archive.md)
-- [Emulator Predictions](emulatorPredictions.md)
-- [Emulators Training](emulatorTraining.md)
-- [Compressed Parameters](compressedParameters.md)
 
 ## Prerequisites
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,4 +1,4 @@
-# Installation
+# INSTALLATION
 (Last updated: Nov 19 2024)
 
 LaCE contains a submodule to estimate compressed parameters from the power spectrum that uses cosmopower. The LaCE installation is slightly different depending on whether you want to use cosmopower or not.

--- a/docs/docs/users/archive.md
+++ b/docs/docs/users/archive.md
@@ -1,4 +1,4 @@
-# Archive
+# ARCHIVE
 
 The LaCE emulators support two types of archives:
 - Gadget archive: Contains the P1D of Gadget simulations described in [Pedersen+21](https://arxiv.org/abs/2011.15127).  

--- a/docs/docs/users/emulatorPredictions.md
+++ b/docs/docs/users/emulatorPredictions.md
@@ -1,4 +1,4 @@
-# Making predictions with LaCE
+# MAKING PREDICTIONS WITH LAKE
 
 ## Loading an emulator 
 The easiest way to load an emulator is to use the `set_emulator` class. This can be done with an [archive](archive.md) or a training set. This will load a trained emulator with the specifications of the emulator label.

--- a/docs/docs/users/emulatorPredictions.md
+++ b/docs/docs/users/emulatorPredictions.md
@@ -1,4 +1,4 @@
-# MAKING PREDICTIONS WITH LAKE
+# MAKING PREDICTIONS WITH LACE
 
 ## Loading an emulator 
 The easiest way to load an emulator is to use the `set_emulator` class. This can be done with an [archive](archive.md) or a training set. This will load a trained emulator with the specifications of the emulator label.

--- a/docs/docs/users/emulatorTraining.md
+++ b/docs/docs/users/emulatorTraining.md
@@ -1,4 +1,4 @@
-# NN - Emulator Training
+# NN - EMULATOR TRAINING
 The training of the emulators is done with the code `train.py`. which is in the `scripts` folder. This code is used to train the emulators with the data available in the repository. 
 
 In order to train the emulator, one needs to specify the training configuration file. This file is a .yaml file that contains the parameters for the training. An example of this file is `config.yaml` in the `scripts` folder. 

--- a/docs/docs/users/index.md
+++ b/docs/docs/users/index.md
@@ -1,0 +1,10 @@
+# USER GUIDE
+
+Welcome to the LaCE user documentation! This section contains information for users who want to use LaCE to make predictions or train new emulators.
+
+## Contents
+
+- [Archive](archive.md)
+- [Emulator Predictions](emulatorPredictions.md)
+- [Emulator Training](emulatorTraining.md)
+- [Compressed Parameters](compressedParameters.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,12 +6,18 @@ theme:
 nav:
   - Home: index.md
   - Installation: installation.md
-  - Emulator:
-    - Training: emulatorTraining.md
-    - Predictions: emulatorPredictions.md
-  - Advanced:
-    - Compressed Parameters: compressedParameters.md
-  - Archive: archive.md
+  - User Guide:
+    - Overview: users/index.md
+    - Archive: users/archive.md
+    - Emulator Predictions: users/emulatorPredictions.md 
+    - Emulator Training: users/emulatorTraining.md
+    - Compressed Parameters: users/compressedParameters.md
+  - Developer Guide:
+    - Overview: developers/index.md
+    - Creating New Emulators: developers/CreateNewEmulator.md
+    - Training Options: developers/trainingOptions.md
+    - Testing: developers/advancedTesting.md
+    - Documentation: developers/documentation.md
 
 # Define the URL where the site will be deployed
 site_url: https://github.com/igmhub/LaCE

--- a/lace/cosmo/fit_linP_cosmopower.py
+++ b/lace/cosmo/fit_linP_cosmopower.py
@@ -118,8 +118,8 @@ class linPCosmologyCosmopower:
             
             for ii in tqdm(range(len(chunk)), desc="Processing samples"):
                 poly_linP = linPCosmologyCosmopower.fit_polynomial(
-                                    xmin = self.fit_min_Mpc * self.kp_Mpc , 
-                                    xmax= self.fit_max_Mpc * self.kp_Mpc , 
+                                    xmin = self.fit_min_Mpc, 
+                                    xmax= self.fit_max_Mpc, 
                                     x = k_Mpc / self.kp_Mpc, 
                                     y = Pk_Mpc[ii], 
                                     deg=2

--- a/lace/cosmo/fit_linP_cosmopower.py
+++ b/lace/cosmo/fit_linP_cosmopower.py
@@ -13,10 +13,10 @@ PROJ_ROOT = Path(__file__).resolve().parents[2]
 
 @dataclass
 class linPCosmologyCosmopower:
-    kp_Mpc : float = 0.7
+    kp_kms : float = 0.009
     z_star : float = 3
-    fit_min_Mpc : float = 0.5
-    fit_max_Mpc : float = 2
+    fit_min_kms : float = 0.5
+    fit_max_kms : float = 2
     cosmopower_model : str = "Pk_cp_NN_sumnu"
 
     def __post_init__(self):
@@ -43,7 +43,7 @@ class linPCosmologyCosmopower:
         #Omega_nu = 3*np.array(params["omega_ncdm"])
         H0 = np.array(params["h"])*100
         Omega_r = 1 - Omega_bc - Omega_lambda
-        Hz = np.sqrt(H0**2 * (Omega_bc*(1+zstar)**3 + Omega_r*(1+zstar)**4 + params["Omega_Lambda"]))
+        Hz = H0 * np.sqrt((Omega_bc*(1+zstar)**3 + Omega_r*(1+zstar)**4 + Omega_lambda))
         return Hz
     
     @staticmethod
@@ -56,24 +56,24 @@ class linPCosmologyCosmopower:
     
     @staticmethod
     def convert_to_kms(params: dict, 
-                        k_hMpc: np.ndarray, 
-                        Pk_hMpc: np.ndarray, 
+                        k_Mpc: np.ndarray, 
+                        Pk_Mpc: np.ndarray, 
                         z_star: float):
         H_z = linPCosmologyCosmopower.measure_Hz(params, zstar = z_star)
-        dvdX = H_z / (1 + z_star) / np.array(params['h'])
-        k_kms = k_hMpc / dvdX[:,None]
-        Pk_kms = Pk_hMpc * dvdX[:,None]**3
+        dvdX = H_z / (1 + z_star) 
+        k_kms = k_Mpc / dvdX[:,None]
+        Pk_kms = Pk_Mpc * (dvdX[:,None]**3)
         return k_kms, Pk_kms
     
     @staticmethod
-    def get_star_params(linP: np.poly1d, 
-                        kp: float):
+    def get_star_params(linP_kms: np.poly1d, 
+                        kp_kms: float):
         # translate the polynomial to our parameters
-        ln_A_star = linP[0]
-        Delta2_star = np.exp(ln_A_star) * kp**3 / (2 * np.pi**2)
-        n_star = linP[1]
+        ln_A_star = linP_kms[0]
+        Delta2_star = np.exp(ln_A_star) * kp_kms**3 / (2 * np.pi**2)
+        n_star = linP_kms[1]
         # note that the curvature is alpha/2
-        alpha_star = 2.0 * linP[2]
+        alpha_star = 2.0 * linP_kms[2]
 
         results = {
             "Delta2_star": Delta2_star,
@@ -107,26 +107,34 @@ class linPCosmologyCosmopower:
         for chunk in chunks:    # create a dict of cosmological parameters
             params = {
                 'H0': [chunk[param_mapping['h']].values[ii]*100 for ii in range(len(chunk))],
+                'h': [chunk[param_mapping['h']].values[ii] for ii in range(len(chunk))],
                 'mnu': [3*chunk[param_mapping['m_ncdm']].values[ii] for ii in range(len(chunk))],
                 'omega_cdm': [chunk[param_mapping['omega_cdm']].values[ii] for ii in range(len(chunk))],
                 'omega_b': [(chunk[param_mapping['Omega_m']].values[ii] - chunk[param_mapping['omega_cdm']].values[ii]/chunk[param_mapping['h']].values[ii]**2) * chunk[param_mapping['h']].values[ii]**2 for ii in range(len(chunk))],
+                'Omega_m': [chunk[param_mapping['Omega_m']].values[ii] for ii in range(len(chunk))],
+                'Omega_Lambda': [chunk[param_mapping['Omega_Lambda']].values[ii] for ii in range(len(chunk))],
                 'As': [np.exp(chunk[param_mapping['ln_A_s_1e10']].values[ii])/1e10 for ii in range(len(chunk))],
                 'ns': [chunk[param_mapping['n_s']].values[ii] for ii in range(len(chunk))]
             }            
             Pk_Mpc = self.cp_emulator.ten_to_predictions_np(params)
             k_Mpc = self.cp_emulator.modes
-            
+
+            k_kms, Pk_kms = linPCosmologyCosmopower.convert_to_kms(params, k_Mpc, Pk_Mpc, z_star = self.z_star)
+
+            kmin_kms = self.fit_min_kms * self.kp_kms
+            kmax_kms = self.fit_max_kms * self.kp_kms  
+
             for ii in tqdm(range(len(chunk)), desc="Processing samples"):
                 poly_linP = linPCosmologyCosmopower.fit_polynomial(
-                                    xmin = self.fit_min_Mpc, 
-                                    xmax= self.fit_max_Mpc, 
-                                    x = k_Mpc / self.kp_Mpc, 
-                                    y = Pk_Mpc[ii], 
+                                    xmin = kmin_kms / self.kp_kms, 
+                                    xmax= kmax_kms / self.kp_kms, 
+                                    x = k_kms[ii] / self.kp_kms, 
+                                    y = Pk_kms[ii], 
                                     deg=2
                                     )
                 
-                results = linPCosmologyCosmopower.get_star_params(linP = poly_linP, 
-                                                                  kp = self.kp_Mpc)
+                results = linPCosmologyCosmopower.get_star_params(linP_kms = poly_linP, 
+                                                                  kp_kms = self.kp_kms)
 
                 linP_cosmology_results.append(results)
 

--- a/lace/emulator/nn_emulator.py
+++ b/lace/emulator/nn_emulator.py
@@ -406,6 +406,15 @@ class NNEmulator(base_emulator.BaseEmulator):
             training_cov = torch.Tensor(training_cov)
         return training_cov
 
+
+    def _get_rescalings_weights(self):
+        weights_rescalings = np.ones(len(self.training_data))
+        if self.emulator_label == "Nyx_alphap_cov": 
+            weights_rescalings[np.where([(d['val_scaling'] not in [0,1] and d['z'] in [2.8, 3,3.2,3.4]) for d in self.training_data])] = 1
+        else:
+            pass
+        return torch.Tensor(weights_rescalings)
+
     def _load_DESIY1_err(self):
         with open(
             self.models_dir / "DESI_cov/rerr_DESI_Y1.json", "r"
@@ -517,9 +526,10 @@ class NNEmulator(base_emulator.BaseEmulator):
         training_data = self._get_training_data_nn()
         training_label = self._get_training_pd1_nn()
         training_cov = self._get_training_cov()
+        weights_rescalings = self._get_rescalings_weights()
 
         trainig_dataset = TensorDataset(
-            training_data, training_label, training_cov, log_kMpc_train
+            training_data, training_label, training_cov, weights_rescalings, log_kMpc_train
         )
         loader_train = DataLoader(
             trainig_dataset, batch_size=self.batch_size, shuffle=True
@@ -530,7 +540,7 @@ class NNEmulator(base_emulator.BaseEmulator):
         t0 = time.time()
 
         for epoch in tqdm(range(self.nepochs), desc="Training epochs"):
-            for datain, p1D_true, P1D_desi_err, logkP1D in loader_train:
+            for datain, p1D_true, P1D_desi_err, weights_rescalings, logkP1D in loader_train:
                 optimizer.zero_grad()
 
                 coeffsPred, coeffs_logerr = self.nn(datain.to(self.device))  #
@@ -554,15 +564,20 @@ class NNEmulator(base_emulator.BaseEmulator):
                     )
                 )
                 P1Dlogerr = torch.log(
-                    torch.sqrt(P1Derr**2 + P1D_desi_err**2 * p1D_true**2)
+                    torch.sqrt(P1Derr**2 + P1D_desi_err.to(self.device)**2 * p1D_true**2)
                 )
 
                 log_prob = (P1Dpred - p1D_true.to(self.device)).pow(2) / (
-                    P1Derr**2 + P1D_desi_err**2 * p1D_true**2
+                    P1Derr**2 + P1D_desi_err.to(self.device)**2 * p1D_true**2
                 ) + 2 * P1Dlogerr
 
-                log_prob = loss_function_weights[None, :] * log_prob
 
+
+                if self.emulator_label == "Nyx_alphap_cov":
+                    log_prob = weights_rescalings.to(self.device)[:,None] * log_prob 
+                else:
+                    log_prob = loss_function_weights[None, :] * log_prob
+                
                 loss = torch.nansum(log_prob, 1)
 
                 loss = torch.nanmean(loss, 0)

--- a/lace/emulator/nn_emulator.py
+++ b/lace/emulator/nn_emulator.py
@@ -410,7 +410,7 @@ class NNEmulator(base_emulator.BaseEmulator):
     def _get_rescalings_weights(self):
         weights_rescalings = np.ones(len(self.training_data))
         if self.emulator_label == "Nyx_alphap_cov": 
-            weights_rescalings[np.where([(d['val_scaling'] not in [0,1] and d['z'] in [2.8, 3,3.2,3.4]) for d in self.training_data])] = 1
+            weights_rescalings[np.where([(d['ind_rescaling'] not in [0,1] and d['z'] in [3,3.2]) for d in self.training_data])] = 1
         else:
             pass
         return torch.Tensor(weights_rescalings)

--- a/lace/utils/plotting_functions.py
+++ b/lace/utils/plotting_functions.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from lace.utils import poly_p1d
 import matplotlib.cm as cm
+import corner
 
 def plot_p1d_vs_emulator(testing_data, emulator, save_path=None):
     """
@@ -84,3 +85,120 @@ def plot_p1d_vs_emulator(testing_data, emulator, save_path=None):
 
     plt.show()
     plt.close()
+
+def create_corner_plot(
+    main_data_dict, 
+    labels=None, 
+    figsize=(8, 8), 
+    additional_data_dicts=None, 
+    additional_colors=None, 
+    legend_labels=None, 
+    truth_values=None,  # Add truth values as a parameter
+    save_path=None
+):
+    """
+    Creates a triangular corner plot with 1-sigma contours, labels, optional overlayed contours, and truth values with a legend.
+
+    Parameters:
+        main_data_dict (dict): Main dictionary where keys are parameter names, and values are 1D arrays of parameter values.
+        labels (list, optional): List of strings for axis labels (LaTeX supported). Defaults to dictionary keys.
+        figsize (tuple, optional): Figure size for the plot. Defaults to (8, 8).
+        additional_data_dicts (list, optional): List of additional dictionaries with parameter data for overlaying contours.
+        additional_colors (list, optional): List of colors for additional datasets. Defaults to None (assigns random colors).
+        legend_labels (list, optional): List of labels for the legend. Defaults to "Dataset 1", "Dataset 2", etc.
+        truth_values (list, optional): List of truth values corresponding to the parameter labels. Defaults to None (no truth points).
+        save_path (str, optional): File path to save the plot. Defaults to None (won't save).
+
+    Returns:
+        matplotlib.figure.Figure: The generated corner plot figure.
+    """    
+
+    # Convert the main dictionary to a 2D array
+    main_data = np.array(list(main_data_dict.values())).T  # Shape (N_samples, N_parameters)
+    
+    # Default labels to dictionary keys if not provided
+    if labels is None:
+        labels = list(main_data_dict.keys())
+    
+    # Generate the base corner plot with the main data
+    figure = corner.corner(
+        main_data,
+        labels=labels,
+        quantiles=[0.16, 0.5, 0.84],  # Show 1-sigma intervals
+        show_titles=False,
+        plot_density=False,
+        plot_datapoints=False,
+        color="steelblue",
+        fill_contours=False,
+        levels=(0.68, 0.95),  # 1-sigma and 2-sigma contours
+        smooth=1.0,  # Smoothing for the KDE
+        scale_hist=True,
+        figsize=figsize,
+    )
+ 
+    ndim = len(labels)
+    axes = np.array(figure.axes).reshape((ndim, ndim))
+
+    if truth_values:
+        # Loop over the diagonal
+        for i in range(ndim):
+            ax = axes[i, i]
+            ax.axvline(truth_values[i], color="black")
+
+        """# Loop over the histograms
+        for yi in range(ndim):
+            for xi in range(yi):
+                ax = axes[yi, xi]
+                ax.axvline(truth_values[xi], color="black")
+                ax.axvline(truth_values[xi], color="black")
+                ax.axhline(truth_values[yi], color="black")
+                ax.axhline(truth_values[yi], color="black")
+                ax.plot(truth_values[xi], truth_values[yi], "black")
+                ax.plot(truth_values[xi], truth_values[yi], "black")"""
+
+    # Overlay contours for additional datasets if provided
+    legend_handles = []
+    if additional_data_dicts:
+        if additional_colors is None:
+            # Generate random colors if not specified
+            additional_colors = [f"C{i}" for i in range(len(additional_data_dicts))]
+            
+        
+        
+        if legend_labels is None:
+            # Generate default labels if not specified
+            legend_labels = [f"Dataset {i+1}" for i in range(len(additional_data_dicts))]
+        
+        for idx, additional_data_dict in enumerate(additional_data_dicts):
+            # Convert the additional dictionary to a 2D array
+            additional_data = np.array(list(additional_data_dict.values())).T  # Shape (N_samples, N_parameters)
+            color = additional_colors[idx % len(additional_colors)]
+            
+            # Overlay contours on existing axes
+            figure = corner.corner(
+                additional_data,
+                fig=figure,  # Use the existing figure
+                color=color,
+                quantiles=[0.16, 0.5, 0.84],
+                plot_density=False,
+                plot_datapoints=False,
+                fill_contours=False,  # No fill for overlays
+                levels=(0.68, 0.95),  # 1-sigma and 2-sigma contours
+                smooth=1.0,
+            )
+            
+            # Add to legend handles
+            legend_handles.append(plt.Line2D([], [], color=color, label=legend_labels[idx+1]))
+    
+    # Add legend for the main data
+    legend_handles.append(plt.Line2D([], [], color="steelblue", label=legend_labels[0]))
+
+    # Add legend to the figure
+    figure.legend(handles=legend_handles, loc='upper right', fontsize=10, frameon=True)
+    
+    # Save the plot if a save path is provided
+    if save_path:
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Corner plot saved to {save_path}")
+
+    plt.show()

--- a/notebooks/Chains_postprocessing.py
+++ b/notebooks/Chains_postprocessing.py
@@ -1,0 +1,120 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: emulators2
+#     language: python
+#     name: emulators2
+# ---
+
+# # THIS NOTEBOOK PLOTS COSMOLOGICAL PARAMETERS FROM MCMC CHAINS
+
+# %load_ext autoreload
+# %autoreload 2
+
+# +
+import corner
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+from lace.utils.plotting_functions import create_corner_plot
+
+
+import matplotlib as mpl
+mpl.rcParams.update(mpl.rcParamsDefault)
+plt.rcParams["font.family"] = "serif"
+# -
+
+# ## DEFINE PATHS TO CHAINS TO BE PLOTTED
+
+file_dirs = [
+    "/pscratch/sd/l/lcabayol/P1D/mockChallengeLym1d/mock_challenge_v0/chains_H067/mock_v2.1.txt",
+    "/pscratch/sd/l/lcabayol/P1D/mockChallengeLym1d/mock_challenge_v0/chains_H074/mock_v2.1.txt"]
+    
+
+# ## OPEN AND SAVE CHAINS IN DATAFRAMES
+
+with open(file_dirs[0], 'r') as file:
+    for line in file:
+        if line.strip().startswith("#"):  # Check for a commented line
+            first_comment = line.strip()
+            break
+    parameters_list = first_comment.lstrip("#").split()
+
+dfs = []
+for file in file_dirs:
+    chains = np.loadtxt(file)
+    df = pd.DataFrame(chains, columns = parameters_list)
+    dfs.append(df)
+
+# ## PLOT COSMOLOGICAL PARAMETERS
+
+# ### DEFINE PARAMETERS TO BE PLOTTED
+
+parameters_of_interest = ["sigma8", "Omega_m", "h"]#omega_cdm
+labels = [r"$\sigma_8$", r"$\Omega_m$", r"$h$"]#\Omega_{\rm cdm} h^2
+
+dirs_list = []
+for df in dfs:
+    dict_ = {}
+    for param in parameters_of_interest:
+        dict_[f"{param}"] = df.loc[:,f'{param}'].values
+    dirs_list.append(dict_)
+
+create_corner_plot(dirs_list[0], 
+                   labels, 
+                  additional_data_dicts = dirs_list[1:],
+                  additional_colors = ['crimson'], 
+                  legend_labels = [r"$H_0 = 67$ km s$^{−1}$ Mpc$^{−1}$",r"$H_0 = 74 $km s$^{−1}$ Mpc$^{−1}$"])
+                  #legend_labels = [r"$\Omega_{\rm cdm} h^2$=0.117",r"$\Omega_{\rm cdm} h^2$=0.13"])
+
+# ## COMPRESSED PARAMETERS WITH COSMOPOWER
+
+from lace.cosmo.fit_linP_cosmopower import linPCosmologyCosmopower
+
+
+fitter_compressed_params = linPCosmologyCosmopower()
+
+# DEFINES THE MAPPING BETWEEN PARAMETER NAMES AND INTERNAL NAMING
+param_mapping = {
+    'h': 'h',
+    'm_ncdm': 'm_ncdm',
+    'omega_cdm': 'omega_cdm',
+    'Omega_m': 'Omega_m',
+    'ln_A_s_1e10': 'ln_A_s_1e10',
+    'n_s': 'n_s'
+}
+
+for ii, df in enumerate(dfs):
+    df['m_ncdm'] = np.zeros(shape = len(df))
+    df['ln_A_s_1e10'] = np.log(df.A_s*1e10)
+    linP_cosmology_results = fitter_compressed_params.fit_linP_cosmology(chains_df = df, 
+                                                                     param_mapping = param_mapping)
+    df_star_params = pd.DataFrame(linP_cosmology_results)
+    df = pd.concat((df, df_star_params),axis=1)
+    dfs[ii] = df
+
+# ## PLOT COMPRESSED PARAMETERS
+
+parameters_of_interest = ["Delta2_star", "n_star", "alpha_star"]
+labels = [r"$\Delta^2_*$", r"$n_*$", r"$\alpha_*$"]
+true_vals = [0.36,-2.3, -0.21]
+
+dirs_list = []
+for df in dfs:
+    dict_ = {}
+    for param in parameters_of_interest:
+        dict_[f"{param}"] = df.loc[:,f'{param}'].values
+    dirs_list.append(dict_)
+
+create_corner_plot(dirs_list[0], 
+                   labels, 
+                  additional_data_dicts = dirs_list[1:],
+                  additional_colors = ['crimson'],
+                  truth_values = true_vals,
+                  legend_labels = [r"$H_0 = 67$ km s$^{−1}$ Mpc$^{−1}$",r"$H_0 = 74$km s$^{−1}$ Mpc$^{−1}$"])

--- a/notebooks/Tutorial_compressedParams.py
+++ b/notebooks/Tutorial_compressedParams.py
@@ -121,12 +121,11 @@ logger.info(f"Percent relative error [%] on alpha_star: {(starparams_CP['alpha_s
 
 df = pd.read_csv(PROJ_ROOT / "data/utils" / "mini_chain_test.csv")
 
-df
-
 df.rename(columns = {'omega_cdm': 'omega_c'}, inplace = True)
 
-# +
-# We need to provide a dictionary that maps the parameter names expected by the emulator to the column names of the dataframe.
+# ##### We need to provide a dictionary that maps the parameter names expected by the emulator to the column names of the dataframe.
+# ##### These parameters must be in the dataframe. They are used either to emulate P(k) or to convert to s/km.
+#
 
 #parameter expected:parameter name in the dataframe   
 param_mapping = {
@@ -138,13 +137,10 @@ param_mapping = {
     'ln_A_s_1e10': 'ln_A_s_1e10',
     'n_s': 'n_s'
 }
-# -
 
 fitter_compressed_params = linPCosmologyCosmopower()
 linP_cosmology_results = fitter_compressed_params.fit_linP_cosmology(chains_df = df, 
                                                                      param_mapping = param_mapping)
-
-linP_cosmology_results
 
 # ## 3. TRAIN COSMOPOWER MODELS
 
@@ -154,7 +150,7 @@ linP_cosmology_results
 
 dict_params_ranges = {
     'ombh2': [0.015, 0.03],
-    'omch2': [0.05, 0.3],
+    'omch2': [0.05, 0.16],
     'H0': [60, 80],
     'ns': [0.8, 1.2],
     'As': [5e-10, 4e-9],


### PR DESCRIPTION
This branch:
- Modifies the notebook and some code in the postprocessing with cosmopower to do it in kms
- Includes the option of weighting snapshots based on redshift and scalings. So far, this has not resulted in better emulators, but it is worth keeping it and explore a bit more
- Adds documentation for developers (to be used tomorrow)
- Adds a notebook to postprocess chains
